### PR TITLE
Changes that will break the pytest and the linter

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -1,14 +1,23 @@
 from utils import is_valid_date
 
 
-def test_is_valid_date():
+def test_is_valid_date_1():
     """
     Test function for is_valid_date().
     """
+    # This one is missing a the extra varieble wich should make the test fail
     assert is_valid_date("2024-03-15") == True
+
+    """
     assert is_valid_date("2024-02-29") == True  # Leap year
     assert is_valid_date("2024-02-30") == False  # Invalid day
     assert is_valid_date("2023-02-29") == False  # Not a leap year
     assert is_valid_date("2024/03/15") == False  # Wrong format
     assert is_valid_date("2024-13-01") == False  # Invalid month
     assert is_valid_date("2024-03-32") == False  # Invalid day
+    """
+
+#added a second test to test wrong output
+def test_is_valid_date_2():
+    # This is not valid since the input is type int and not a date
+    assert is_valid_date("2024-03-15", None) == False  # Invalid input

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import datetime
 
-
-def is_valid_date(date_string):
+# Added a extra variebel to make the unit test fail 
+def is_valid_date(date_string, extra):
     """
     Checks if a date is valid in the format "yyyy-mm-dd".
 


### PR DESCRIPTION
I added an additional  parameter to the function "is_valid_date" and I also added a second test to the unit test. The first test doesn't include the new  parameter and should therefore break and the second test should break because it has the wrong output.
I also changed one line in the main file where I removed the spaces from an equal sign which should break the linter. 
I also added the parameter "None" where "is_valid_date" is called in order for the code to still be functional. 